### PR TITLE
Fix authentication button issues

### DIFF
--- a/ios/Skratch/SkratchApp.swift
+++ b/ios/Skratch/SkratchApp.swift
@@ -92,8 +92,7 @@ struct LoginView: View {
 
             // Skip for offline use
             Button("Continue without account") {
-                // Allow offline use with local data only
-                // This won't set isAuthenticated but will dismiss login
+                authManager.continueWithoutAccount()
             }
             .font(.footnote)
             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Fix "Continue without account" button - was doing nothing, now properly enables offline mode
- Fix Sign in with Apple error 1000 by adding presentation context provider
- Persist offline mode choice across app restarts

## Changes
- `AuthManager.swift`: Add `isOfflineMode` flag, `continueWithoutAccount()` method, and `ASAuthorizationControllerPresentationContextProviding` conformance
- `SkratchApp.swift`: Wire up button to call `authManager.continueWithoutAccount()`

## Test plan
- [x] Build succeeds
- [x] All 31 unit tests pass
- [ ] Manual: Tap "Continue without account" → should show main app
- [ ] Manual: Restart app after offline mode → should stay in main app
- [ ] Manual: Sign in with Apple → should show Apple auth UI (may still fail without proper entitlements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)