### PR TITLE
Add expanded feature roadmap with 23 planned features

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -173,16 +173,52 @@ xcodebuild test -project ios/Footprint.xcodeproj -scheme Footprint -destination 
 
 ## Future Features Roadmap (Priority Order)
 
+### Completed
 | # | Feature | Description | Status |
 |---|---------|-------------|--------|
 | 1 | **Live location tracking** | Request location permission, show current position on map, auto-detect visited places | ✅ DONE |
 | 2 | **iOS Widget** | Home screen widget showing travel stats (code ready, add target in Xcode) | ✅ DONE |
 | 3 | **Friend lists & sharing** | Connect with friends, share/compare travel lists (backend + iOS UI complete) | ✅ DONE |
-| 4 | **Feature requests & feedback** | In-app feedback form that saves to DynamoDB for async review | 🔲 TODO |
-| 5 | **Gmail/Calendar import** | Read travel confirmations from email/calendar, suggest locations to add | 🔲 TODO |
-| 6 | **States for other countries** | Add state/province boundaries for Australia, Mexico, etc. | 🔲 TODO |
-| 7 | **Cities & Landmarks** | Track visited cities and famous landmarks | 🔲 TODO |
-| 8 | **macOS app** | Native Mac app (Universal purchase) | 🔲 TODO |
+
+### High Priority - Core Features
+| # | Feature | Description | Status |
+|---|---------|-------------|--------|
+| 4 | **Bucket list mode** | Mark places you WANT to visit, toggle between "visited" and "want to visit" | 🔲 TODO |
+| 5 | **Travel timeline** | Add visit dates to places, "When did I visit France?", chronological history | 🔲 TODO |
+| 6 | **Photos & memories** | Attach photos to visited places, integrate with Photos app | 🔲 TODO |
+| 7 | **Photo library import** | Scan photo library GPS metadata, auto-suggest places you've visited | 🔲 TODO |
+| 8 | **Badges & achievements** | Gamification: "10 countries", "All US states", "Europe explorer", unlock rewards | 🔲 TODO |
+| 9 | **Push notifications** | "You're near a new country!", weekly travel stats, achievement unlocks | 🔲 TODO |
+
+### Medium Priority - Expanded Tracking
+| # | Feature | Description | Status |
+|---|---------|-------------|--------|
+| 10 | **Transit vs visited** | Distinguish "passed through/layover" from "actually visited" for each place | 🔲 TODO |
+| 11 | **National Parks** | Track national parks visited (US 63 parks, expand globally) | 🔲 TODO |
+| 12 | **Continent statistics** | "You've visited 45% of Europe" - breakdown by continent/region | 🔲 TODO |
+| 13 | **Time zones visited** | Fun stat: track how many of the 24 time zones you've been in | 🔲 TODO |
+| 14 | **States for other countries** | Add state/province boundaries for Australia, Mexico, etc. | 🔲 TODO |
+| 15 | **Cities & landmarks** | Track visited cities and famous landmarks | 🔲 TODO |
+
+### Platform Expansion
+| # | Feature | Description | Status |
+|---|---------|-------------|--------|
+| 16 | **Apple Watch app** | Quick glance at stats, complications, "countries visited" on wrist | 🔲 TODO |
+| 17 | **macOS app** | Native Mac app (Universal purchase) | 🔲 TODO |
+
+### Social & Sharing
+| # | Feature | Description | Status |
+|---|---------|-------------|--------|
+| 18 | **Friends leaderboard** | Compare travel stats with friends, rankings, friendly competition | 🔲 TODO (long-term) |
+| 19 | **Feature requests & feedback** | In-app feedback form that saves to DynamoDB for async review | 🔲 TODO |
+
+### Future Ideas
+| # | Feature | Description | Status |
+|---|---------|-------------|--------|
+| 20 | **Gmail/Calendar import** | Read travel confirmations from email/calendar, suggest locations to add | 🔲 TODO |
+| 21 | **Annual travel summary** | Year-end recap like "Spotify Wrapped" for travel | 🔲 TODO |
+| 22 | **UNESCO World Heritage Sites** | Track 1,199 heritage sites visited | 🔲 TODO |
+| 23 | **Siri Shortcuts** | "Hey Siri, add Japan to my visited places" | 🔲 TODO |
 
 ## Notes & Learnings
 - Swift 6 strict concurrency requires `nonisolated(unsafe)` for test mocks


### PR DESCRIPTION
New features added:
- Bucket list mode, travel timeline, photos & memories
- Photo library GPS import, badges/achievements, push notifications
- Transit vs visited, national parks, continent/timezone stats
- Apple Watch app, friends leaderboard, annual travel summary
- UNESCO sites, Siri shortcuts

Reorganized into priority sections: High, Medium, Platform, Social, Future