### PR TITLE
Fix build: make EnumerationResult private

### DIFF
--- a/ios/Footprint/Services/PhotoImportManager.swift
+++ b/ios/Footprint/Services/PhotoImportManager.swift
@@ -511,7 +511,7 @@ final class PhotoImportManager: NSObject {
     }
 
     /// Result from photo enumeration including statistics
-    struct EnumerationResult: Sendable {
+    private struct EnumerationResult: Sendable {
         let clusters: [String: PhotoCluster]
         let totalPhotos: Int
         let photosWithLocation: Int


### PR DESCRIPTION
EnumerationResult uses PhotoCluster which is private, so it must also be private.

https://claude.ai/code/session_01Wjqp5Y5uEipUXfABeJ9Yuq