### PR TITLE
Fix build: use macos-14 runner with Xcode 15.4

### DIFF
--- a/.github/workflows/0-build.yml
+++ b/.github/workflows/0-build.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   build:
     name: Build & Archive
-    runs-on: macos-15
+    runs-on: macos-14
     outputs:
       build_number: ${{ steps.version.outputs.build }}
       version: ${{ steps.version.outputs.version }}
@@ -47,8 +47,8 @@ jobs:
 
     - name: Select Xcode
       run: |
-        # Use latest Xcode available on GitHub runner
-        sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer || sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+        # Use Xcode 15.4 on macos-14 runner (has iOS 17 SDK)
+        sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer || sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
         xcodebuild -version
 
     - name: Install XcodeGen


### PR DESCRIPTION
macos-15 with Xcode 16.2 doesn't have iOS 18.2 SDK pre-installed. Use macos-14 with Xcode 15.4 which has iOS 17 SDK.

https://claude.ai/code/session_01Wjqp5Y5uEipUXfABeJ9Yuq