### PR TITLE
Fix build: pass version numbers to xcodebuild

### DIFF
--- a/.github/workflows/0-build.yml
+++ b/.github/workflows/0-build.yml
@@ -130,7 +130,9 @@ jobs:
           -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_KEY_ID }} \
           -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
           CODE_SIGN_STYLE=Automatic \
-          DEVELOPMENT_TEAM=${{ env.TEAM_ID }}
+          DEVELOPMENT_TEAM=${{ env.TEAM_ID }} \
+          CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build }} \
+          MARKETING_VERSION=${{ steps.version.outputs.version }}
 
     - name: Create ExportOptions.plist
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Fixed build workflow to pass `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` to xcodebuild
- Resolves issue where IPA was being built with wrong build number due to `GENERATE_INFOPLIST_FILE=YES` in project.yml
- Ensures correct build number is embedded for App Store Connect uploads

## Problem
The TestFlight upload was failing because:
1. Build 155 was calculated correctly from git commit count
2. Info.plist was updated, but Xcode ignores it when `GENERATE_INFOPLIST_FILE=YES`
3. The actual IPA contained CFBundleVersion="24" instead of "155"
4. App Store Connect rejected the upload as duplicate (build 24 already exists)

## Test plan
- [ ] Merge this PR
- [ ] Trigger build workflow
- [ ] Verify IPA contains correct build number
- [ ] Run TestFlight Internal workflow
- [ ] Verify successful upload to App Store Connect

https://claude.ai/code/session_01PMaxc2VCqU384qVnQivF6F