### PR TITLE
Fix concurrency: mark PhotoLocationStore as @MainActor

### DIFF
--- a/ios/Footprint/Models/PhotoLocation.swift
+++ b/ios/Footprint/Models/PhotoLocation.swift
@@ -39,6 +39,7 @@ struct PhotoLocation: Identifiable, Codable, Equatable {
 }
 
 /// Manager for storing and retrieving photo locations
+@MainActor
 class PhotoLocationStore {
     static let shared = PhotoLocationStore()
 


### PR DESCRIPTION
## Summary
- Add `@MainActor` annotation to `PhotoLocationStore` class
- Fixes Xcode 26 strict concurrency check error for static shared property

## Test plan
- [ ] Verify build passes on macos-26 runner

https://claude.ai/code/session_01PMaxc2VCqU384qVnQivF6F