### PR TITLE
Fix Google login and add Route53 domain configuration

### DIFF
--- a/ios/Footprint/ContentView.swift
+++ b/ios/Footprint/ContentView.swift
@@ -123,10 +123,22 @@ struct SettingsView: View {
                         .padding(.vertical, 4)
                     }
 
-                    Button(role: .destructive) {
-                        showingSignOutAlert = true
-                    } label: {
-                        Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                    // Show Login button when in offline mode, Sign Out when logged in with account
+                    if AuthManager.shared.isOfflineMode && AuthManager.shared.user == nil {
+                        Button {
+                            // Sign out from offline mode to go back to login screen
+                            Task {
+                                await AuthManager.shared.signOut()
+                            }
+                        } label: {
+                            Label("Sign In", systemImage: "person.crop.circle.badge.plus")
+                        }
+                    } else {
+                        Button(role: .destructive) {
+                            showingSignOutAlert = true
+                        } label: {
+                            Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Fix Settings view to show "Sign In" button when in offline mode instead of "Sign Out"
- Add Route53 hosted zone for footprintmaps.com with automatic DNS record management
- Configure ACM certificates with automatic DNS validation records
- Add DNS A records for api.footprintmaps.com and footprintmaps.com
- Add www subdomain support for the marketing website

https://claude.ai/code/session_01MQxWjkx8a1nwNU4z1xTGC8