### PR TITLE
Feature: macOS app support (Mac Catalyst)

### DIFF
--- a/ios/Footprint.xcodeproj/project.pbxproj
+++ b/ios/Footprint.xcodeproj/project.pbxproj
@@ -772,7 +772,9 @@
 				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wouterdevriendt.footprint;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = 1;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Debug;
 		};
@@ -889,7 +891,9 @@
 				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wouterdevriendt.footprint;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = 1;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,6";
 			};
 			name = Release;
 		};

--- a/ios/Footprint/ContentView.swift
+++ b/ios/Footprint/ContentView.swift
@@ -1337,6 +1337,15 @@ struct StateMapSheet: View {
     @State private var selectedState: String?
     @State private var showingStatePopup = false
 
+    /// Screen height that works on both iOS and macOS (Mac Catalyst)
+    private var screenHeight: CGFloat {
+        #if targetEnvironment(macCatalyst)
+        return 800 // Reasonable default for Mac windows
+        #else
+        return UIScreen.main.bounds.height
+        #endif
+    }
+
     private var regionType: VisitedPlace.RegionType {
         GeographicData.regionType(for: countryCode) ?? .usState
     }
@@ -1411,7 +1420,7 @@ struct StateMapSheet: View {
                         }
                     )
                 }
-                .frame(maxHeight: showStateList ? UIScreen.main.bounds.height * 0.4 : .infinity)
+                .frame(maxHeight: showStateList ? screenHeight * 0.4 : .infinity)
 
                 // Expandable state list
                 VStack(spacing: 0) {
@@ -1462,12 +1471,14 @@ struct StateMapSheet: View {
                                 }
                             }
                         }
-                        .frame(maxHeight: UIScreen.main.bounds.height * 0.5)
+                        .frame(maxHeight: screenHeight * 0.5)
                     }
                 }
             }
             .navigationTitle(countryName)
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Done") {

--- a/ios/Footprint/Import/Views/ImportSourcesView.swift
+++ b/ios/Footprint/Import/Views/ImportSourcesView.swift
@@ -77,7 +77,9 @@ struct ImportSourcesView: View {
                 */
             }
             .navigationTitle("Import Sources")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {

--- a/ios/Footprint/Import/Views/ImportView.swift
+++ b/ios/Footprint/Import/Views/ImportView.swift
@@ -14,7 +14,9 @@ struct ImportView: View {
         NavigationStack {
             content
                 .navigationTitle("Import Travel History")
+                #if os(iOS)
                 .navigationBarTitleDisplayMode(.inline)
+                #endif
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") {

--- a/ios/Footprint/Services/PhotoImportManager.swift
+++ b/ios/Footprint/Services/PhotoImportManager.swift
@@ -1,4 +1,6 @@
+#if canImport(BackgroundTasks)
 import BackgroundTasks
+#endif
 import CoreLocation
 import os
 import Photos
@@ -181,7 +183,9 @@ final class PhotoImportManager: NSObject {
 
     // Note: CLGeocoder instances can only process one request at a time.
     // We create a new instance per geocoding request to enable true parallelism.
+    #if !targetEnvironment(macCatalyst)
     private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
+    #endif
     private var currentScanTask: Task<Void, Never>?
     private var isObservingPhotoLibrary = false
 
@@ -342,6 +346,7 @@ final class PhotoImportManager: NSObject {
 
     /// Register background task handler - call from app delegate
     static func registerBackgroundTask() {
+        #if !targetEnvironment(macCatalyst)
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundTaskIdentifier,
             using: nil
@@ -354,8 +359,10 @@ final class PhotoImportManager: NSObject {
                 await PhotoImportManager.handleBackgroundTask(processingTask)
             }
         }
+        #endif
     }
 
+    #if !targetEnvironment(macCatalyst)
     /// Handle background processing task
     private static func handleBackgroundTask(_ task: BGProcessingTask) async {
         let manager = PhotoImportManager()
@@ -371,9 +378,11 @@ final class PhotoImportManager: NSObject {
 
         task.setTaskCompleted(success: !Task.isCancelled)
     }
+    #endif
 
     /// Schedule background processing task
     private func scheduleBackgroundTask() {
+        #if !targetEnvironment(macCatalyst)
         let request = BGProcessingTaskRequest(identifier: Self.backgroundTaskIdentifier)
         request.requiresNetworkConnectivity = true // Geocoding needs network
         request.requiresExternalPower = false
@@ -383,6 +392,7 @@ final class PhotoImportManager: NSObject {
         } catch {
             print("Failed to schedule background task: \(error)")
         }
+        #endif
     }
 
     /// Check if currently scanning
@@ -440,18 +450,22 @@ final class PhotoImportManager: NSObject {
     }
 
     private func beginBackgroundTask() {
+        #if !targetEnvironment(macCatalyst)
         guard backgroundTaskID == .invalid else { return }
 
         backgroundTaskID = UIApplication.shared.beginBackgroundTask(withName: "PhotoImport") { [weak self] in
             // Time expired - save progress and end task
             self?.endBackgroundTask()
         }
+        #endif
     }
 
     private func endBackgroundTask() {
+        #if !targetEnvironment(macCatalyst)
         guard backgroundTaskID != .invalid else { return }
         UIApplication.shared.endBackgroundTask(backgroundTaskID)
         backgroundTaskID = .invalid
+        #endif
     }
 
     private func showBackgroundNotification() {

--- a/ios/Footprint/Views/PhotoGalleryView.swift
+++ b/ios/Footprint/Views/PhotoGalleryView.swift
@@ -48,7 +48,9 @@ struct PhotoGalleryView: View {
                 }
             }
             .navigationTitle("\(assets.count) Photo\(assets.count == 1 ? "" : "s")")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") {
@@ -168,7 +170,9 @@ struct PhotoDetailView: View {
                     }
                 }
             }
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button {

--- a/ios/Footprint/Views/PhotoImportView.swift
+++ b/ios/Footprint/Views/PhotoImportView.swift
@@ -71,7 +71,9 @@ struct PhotoImportView: View {
                 }
             }
             .navigationTitle("Import from Photos")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     if importManager.isScanning {
@@ -1018,7 +1020,9 @@ private struct UnmatchedCoordinatesMapView: View {
             }
             .mapStyle(.standard)
             .navigationTitle("Unmatched Locations (\(coordinates.count))")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
@@ -1089,7 +1093,9 @@ private struct UnmatchedPhotoDetailView: View {
                 }
             }
             .navigationTitle("Unmatched Location")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }


### PR DESCRIPTION
## Summary
- Enables Mac Catalyst support for universal purchase across iPhone, iPad, and Mac
- Adds platform guards (`#if !targetEnvironment(macCatalyst)`) around BackgroundTasks APIs (BGTaskScheduler, BGProcessingTask, UIBackgroundTaskIdentifier) which are non-functional on macOS
- Replaces `UIScreen.main.bounds.height` with a platform-aware computed property
- Wraps `.navigationBarTitleDisplayMode(.inline)` with `#if os(iOS)` across all views
- Removes phantom file references (ShareCardView.swift, YearInReviewView.swift) from project.pbxproj

## Test plan
- [x] Verified macOS (Mac Catalyst) build succeeds with `xcodebuild build -destination 'platform=macOS,variant=Mac Catalyst'`
- [x] Verified iOS Simulator build still succeeds with `xcodebuild build -destination 'platform=iOS Simulator,name=iPhone 17'`
- [ ] Manual testing: launch app on Mac, verify map, countries list, stats, and settings tabs work
- [ ] Manual testing: verify photo import flow works on Mac (without background task scheduling)
- [ ] Manual testing: verify Sign in with Apple works on Mac

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)