### PR TITLE
Disable cron on TestFlight external review monitor (stop spam)

### DIFF
--- a/.github/workflows/monitor-testflight-external.yml
+++ b/.github/workflows/monitor-testflight-external.yml
@@ -4,8 +4,6 @@ name: Monitor TestFlight External Review
 # Sends notification when build becomes available
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'  # Every 10 minutes
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- The \`Monitor TestFlight External Review\` workflow runs every 10 minutes and has been failing with \`App not found: com.wouterdevriendt.footprint\` from the ASC API — spamming ~144 failure emails/day.
- It was added alongside the March 22 one-time external submission (\`submit-external-once.yml\`). That review has long since completed, so the monitor has outlived its purpose.
- Removes the \`schedule:\` trigger; keeps \`workflow_dispatch\` so it can still be manually triggered if needed.

## Test plan
- [ ] Confirm no new scheduled runs appear on the Actions tab after merge
- [ ] Manually trigger via \`gh workflow run "Monitor TestFlight External Review"\` if we ever re-submit for external review