### PR TITLE
Fix Infrastructure Deploy: seed pip into uv venv

### DIFF
--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build Lambda package
         run: |
           cd infrastructure
-          uv venv
+          uv venv --seed
           uv pip install -r requirements.txt
           uv run python deploy_lambda.py
 
@@ -110,7 +110,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           cd infrastructure
-          uv venv
+          uv venv --seed
           uv pip install -r requirements.txt
 
       - name: Pulumi login


### PR DESCRIPTION
Pulumi calls `pip list` to discover Python deps. `uv venv` doesn't include pip by default; `--seed` does. Failing on every push since 2026-03-22.