### PR TITLE
Drop stray .github/README.md masking the real one

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,1 +1,0 @@
-# Trigger workflow test


### PR DESCRIPTION
## Summary

Right now https://github.com/wdvr/footprint renders just one line — \"Trigger workflow test\" — because there's a \`.github/README.md\` file checked in with that content. GitHub's README lookup prefers \`.github/README.md\` over the root \`README.md\`, so the real, comprehensive README isn't being shown.

The file was added in 7c92c03 (\"Test workflow trigger\") — looks like a debugging artifact that never got cleaned up.

Deleting it. No workflow references it (grepped \`.github/workflows/\` and the rest of the tree). After merge, the root README will be the one shown.

## Test plan

- [ ] After merge, https://github.com/wdvr/footprint renders the full README starting with \"# Footprint - Travel Tracker\"