### PR TITLE
App Store badge: link to real listing, drop 'Coming Soon'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://apps.apple.com/app/footprint-travel-tracker">
-    <img src="https://img.shields.io/badge/App_Store-Coming_Soon-blue?style=flat&logo=apple" alt="App Store">
+  <a href="https://apps.apple.com/app/footprint-travel-map/id6758334183">
+    <img src="https://img.shields.io/badge/App_Store-Download-007AFF?style=flat-square&logo=apple&logoColor=white" alt="App Store">
   </a>
   <a href="https://footprintmaps.com">
     <img src="https://img.shields.io/badge/Website-footprintmaps.com-green?style=flat" alt="Website">


### PR DESCRIPTION
## Summary

The README has had an App Store badge reading **Coming Soon** for a while, pointing at a stale slug (`apps.apple.com/app/footprint-travel-tracker`). The app is now live — point the badge at the actual listing and update the label.

- URL: `https://apps.apple.com/app/footprint-travel-map/id6758334183`
- App ID and slug found via the public App Store / MWM listing for "Footprint - Travel Map by Wouter Devriendt"
- Badge style nudged to `flat-square` + the Apple-blue (#007AFF) and a white Apple logo

If the app ID is wrong (e.g. you used a different listing) let me know and I'll fix it.

## Test plan
- [ ] Badge label reads "App Store · Download"
- [ ] Clicking it opens https://apps.apple.com/app/footprint-travel-map/id6758334183